### PR TITLE
Test with chinesedfan/awesome-lint#test_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - 'node'
+git:
+  depth: false
 
 before_install:
   # - rvm install 2.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ node_js:
   - 'node'
 
 before_install:
-  - rvm install 2.2.2
+  # - rvm install 2.2.2
 
 install:
-  # - npm install --global awesome-lint
-  - gem install awesome_bot
+  - npm install --global https://github.com/chinesedfan/awesome-lint.git#test_ci
+  # - gem install awesome_bot
 
 script:
-  # - awesome-lint README.md
-  - awesome_bot README.md --allow-redirect --allow-dupe
+  - awesome-lint README.md
+  # - awesome_bot README.md --allow-redirect --allow-dupe
 
 notifications:
   email:


### PR DESCRIPTION
This PR replaces my customized awesome-lint with awesome_bot, which explains https://github.com/sindresorhus/awesome-lint/issues/45.

The reason is that travis CI only clones with `depth=50` by default, see [document](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth). When awesome-lint tries to find the oldest commit, it mistook the 50th latest one. To fix it, we should set depth to false in .travis.yml. You can find a build log without `git-repo-age` error [here](https://travis-ci.org/chinesedfan/awesome-microbit/builds/510198545).

For other lint errors, https://github.com/sindresorhus/awesome-lint/pull/63, https://github.com/sindresorhus/awesome-lint/pull/65, and https://github.com/sindresorhus/awesome-lint/pull/66 may help.